### PR TITLE
fix: import inliner_cfg/summary_cfg from certoraDevVerify

### DIFF
--- a/envs/cvlr_envs.just
+++ b/envs/cvlr_envs.just
@@ -1,0 +1,11 @@
+certora-scripts := "."
+
+core_inliner_cfg := certora-scripts  / "cvlr_inlining_core.txt"
+anchor_inliner_cfg := certora-scripts  / "cvlr_inlining_anchor.txt"
+package_inliner_cfg := certora-scripts  / "cvlr_inlining_package.txt"
+inliner_cfg   := certora-scripts  / "cvlr_inlining.txt"
+
+core_summaries_cfg := certora-scripts  / "cvlr_summaries_core.txt"
+anchor_summaries_cfg := certora-scripts  / "cvlr_summaries_anchor.txt"
+package_summaries_cfg := certora-scripts  / "cvlr_summaries_package.txt"
+summaries_cfg := certora-scripts  / "cvlr_summaries.txt"

--- a/envs/justfile
+++ b/envs/justfile
@@ -2,7 +2,7 @@
 ## This script is intended to be run only once during the project setup
 ##------------------------------------------------------------------------##
 
-certora-scripts := "."
+import "cvlr_envs.just"
 
 export HEADER := '''
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -11,17 +11,6 @@ export HEADER := '''
 ;;
 ;;
 '''
-
-core_inliner_cfg := certora-scripts  / "cvlr_inlining_core.txt"
-anchor_inliner_cfg := certora-scripts  / "cvlr_inlining_anchor.txt"
-package_inliner_cfg := certora-scripts  / "cvlr_inlining_package.txt"
-inliner_cfg   := certora-scripts  / "cvlr_inlining.txt"
-
-core_summaries_cfg := certora-scripts  / "cvlr_summaries_core.txt"
-anchor_summaries_cfg := certora-scripts  / "cvlr_summaries_anchor.txt"
-package_summaries_cfg := certora-scripts  / "cvlr_summaries_package.txt"
-summaries_cfg := certora-scripts  / "cvlr_summaries.txt"
-
 
 refresh:
   # download core and anchor files

--- a/just/certoraDevVerify.just
+++ b/just/certoraDevVerify.just
@@ -4,6 +4,7 @@
 
 import "build.just"
 import "certoraSolanaProver.just"
+import "../envs/cvlr_envs.just"
 
 # java executable
 export JAVA := env_var_or_default("JAVA", "java")


### PR DESCRIPTION
This commit fixes this error 

```
j build-sbf
error: Variable `inliner_cfg` not defined
  ——▶ src/certora/just/certoraDevVerify.just:55:22
   │
55 │         -solanaInlining {{ inliner_cfg }} \
   │                            ^^^^^^^^^^^
 ```